### PR TITLE
refactor: parameterize handshake patterns and introduce new handshake pattern

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,4 +1,4 @@
-import { ChaCha20Poly1305, TAG_LENGTH } from "@stablelib/chacha20poly1305";
+import { ChaCha20Poly1305 } from "@stablelib/chacha20poly1305";
 import { Hash } from "@stablelib/hash";
 import { HKDF as hkdf } from "@stablelib/hkdf";
 import { hash } from "@stablelib/sha256";
@@ -9,8 +9,6 @@ import type { bytes32 } from "./@types/basic.js";
 import type { KeyPair } from "./@types/keypair.js";
 
 export const Curve25519KeySize = x25519.PUBLIC_KEY_LENGTH;
-
-export const ChachaPolyTagLen = TAG_LENGTH;
 
 /**
  * Generate hash using SHA2-256

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,6 +1,7 @@
 import { ChaCha20Poly1305, TAG_LENGTH } from "@stablelib/chacha20poly1305";
+import { Hash } from "@stablelib/hash";
 import { HKDF as hkdf } from "@stablelib/hkdf";
-import { hash, SHA256 } from "@stablelib/sha256";
+import { hash } from "@stablelib/sha256";
 import * as x25519 from "@stablelib/x25519";
 import { concat as uint8ArrayConcat } from "uint8arrays/concat";
 
@@ -43,9 +44,15 @@ export function intoCurve25519Key(s: Uint8Array): bytes32 {
  * @param numKeys number of keys to generate
  * @returns array  of `numValues` length containing Uint8Array keys of a given byte `length`
  */
-export function HKDF(ck: bytes32, ikm: Uint8Array, length: number, numKeys: number): Array<Uint8Array> {
+export function HKDF(
+  hash: new () => Hash,
+  ck: bytes32,
+  ikm: Uint8Array,
+  length: number,
+  numKeys: number
+): Array<Uint8Array> {
   const numBytes = length * numKeys;
-  const okm = new hkdf(SHA256, ikm, ck).expand(numBytes);
+  const okm = new hkdf(hash, ikm, ck).expand(numBytes);
   const result = [];
   for (let i = 0; i < numBytes; i += length) {
     const k = okm.subarray(i, i + length);

--- a/src/dh25519.ts
+++ b/src/dh25519.ts
@@ -1,0 +1,52 @@
+import * as x25519 from "@stablelib/x25519";
+
+import type { bytes32 } from "./@types/basic.js";
+import type { KeyPair } from "./@types/keypair.js";
+import { DHKey } from "./crypto.js";
+
+export class DH25519 implements DHKey {
+  intoKey(s: Uint8Array): bytes32 {
+    if (s.length != x25519.PUBLIC_KEY_LENGTH) {
+      throw new Error("invalid public key length");
+    }
+
+    return s;
+  }
+
+  generateKeyPair(): KeyPair {
+    const keypair = x25519.generateKeyPair();
+
+    return {
+      publicKey: keypair.publicKey,
+      privateKey: keypair.secretKey,
+    };
+  }
+
+  generateKeyPairFromSeed(seed: bytes32): KeyPair {
+    const keypair = x25519.generateKeyPairFromSeed(seed);
+
+    return {
+      publicKey: keypair.publicKey,
+      privateKey: keypair.secretKey,
+    };
+  }
+
+  DH(privateKey: bytes32, publicKey: bytes32): bytes32 {
+    try {
+      const derivedU8 = x25519.sharedKey(privateKey, publicKey);
+
+      if (derivedU8.length === 32) {
+        return derivedU8;
+      }
+
+      return derivedU8.subarray(0, 32);
+    } catch (e) {
+      console.error(e);
+      return new Uint8Array(32);
+    }
+  }
+
+  DHLen(): number {
+    return x25519.PUBLIC_KEY_LENGTH;
+  }
+}

--- a/src/handshake.ts
+++ b/src/handshake.ts
@@ -173,7 +173,7 @@ export class Handshake {
 
   // Generates an 8 decimal digits authorization code using HKDF and the handshake state
   genAuthcode(): string {
-    const [output0] = HKDF(this.hs.ss.h, new Uint8Array(), 8, 1);
+    const [output0] = HKDF(this.hs.handshakePattern.hash, this.hs.ss.h, new Uint8Array(), 8, 1);
     const bn = new BN(output0);
     const code = bn.mod(new BN(100_000_000)).toString().padStart(8, "0");
     return code.toString();

--- a/src/handshake_state.ts
+++ b/src/handshake_state.ts
@@ -31,19 +31,14 @@ export class HandshakeState {
   re?: bytes32;
   ss: SymmetricState;
   initiator: boolean;
-  handshakePattern: HandshakePattern;
   msgPatternIdx: number;
-  psk: Uint8Array;
 
-  constructor(hsPattern: HandshakePattern, psk: Uint8Array) {
+  constructor(public readonly handshakePattern: HandshakePattern, public psk: Uint8Array) {
     // By default the Handshake State initiator flag is set to false
     // Will be set to true when the user associated to the handshake state starts an handshake
     this.initiator = false;
 
-    this.handshakePattern = hsPattern;
-    this.psk = psk;
-
-    this.ss = new SymmetricState(hsPattern);
+    this.ss = new SymmetricState(handshakePattern);
 
     this.msgPatternIdx = 0;
   }
@@ -101,14 +96,14 @@ export class HandshakeState {
   }
 
   genMessageNametagSecrets(): { nms1: Uint8Array; nms2: Uint8Array } {
-    const [nms1, nms2] = HKDF(this.ss.h, new Uint8Array(), 2, 32);
+    const [nms1, nms2] = HKDF(this.handshakePattern.hash, this.ss.h, new Uint8Array(), 2, 32);
     return { nms1, nms2 };
   }
 
   // Uses the cryptographic information stored in the input handshake state to generate a random message nametag
   // In current implementation the messageNametag = HKDF(handshake hash value), but other derivation mechanisms can be implemented
   toMessageNametag(): MessageNametag {
-    const [output] = HKDF(this.ss.h, new Uint8Array(), 32, 1);
+    const [output] = HKDF(this.handshakePattern.hash, this.ss.h, new Uint8Array(), 32, 1);
     return output.subarray(0, MessageNametagLength);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {
   NoiseSecureTransferDecoder,
   NoiseSecureTransferEncoder,
 } from "./codec.js";
-import { generateX25519KeyPair, generateX25519KeyPairFromSeed } from "./crypto.js";
+import { DH25519 } from "./dh25519.js";
 import {
   Handshake,
   HandshakeParameters,
@@ -35,7 +35,7 @@ export {
   MessageNametagError,
   StepHandshakeParameters,
 };
-export { generateX25519KeyPair, generateX25519KeyPairFromSeed };
+export { DH25519 as X25519DHKey };
 export {
   HandshakePattern,
   MessageDirection,

--- a/src/messagenametag.ts
+++ b/src/messagenametag.ts
@@ -1,8 +1,8 @@
+import { hash } from "@stablelib/sha256";
 import { concat as uint8ArrayConcat } from "uint8arrays/concat";
 import { equals as uint8ArrayEquals } from "uint8arrays/equals";
 
 import { MessageNametag } from "./@types/handshake.js";
-import { hashSHA256 } from "./crypto.js";
 import { writeUIntLE } from "./utils.js";
 
 export const MessageNametagLength = 16;
@@ -40,6 +40,7 @@ export class MessageNametagBuffer {
     if (this.secret) {
       for (let i = 0; i < this.buffer.length; i++) {
         const counterBytesLE = writeUIntLE(new Uint8Array(8), this.counter, 0, 8);
+        // TODO: determine if this hash should be sha256, or if it should depend on the handshake pattern
         const d = hashSHA256(uint8ArrayConcat([this.secret, counterBytesLE]));
         this.buffer[i] = toMessageNametag(d);
         this.counter++;
@@ -123,4 +124,13 @@ export class MessageNametagBuffer {
       console.debug("The message nametags buffer has no secret set");
     }
   }
+}
+
+/**
+ * Generate hash using SHA2-256
+ * @param data data to hash
+ * @returns hash digest
+ */
+function hashSHA256(data: Uint8Array): Uint8Array {
+  return hash(data);
 }

--- a/src/pairing.spec.ts
+++ b/src/pairing.spec.ts
@@ -7,7 +7,7 @@ import { pEvent } from "p-event";
 import { equals as uint8ArrayEquals } from "uint8arrays/equals";
 
 import { NoiseHandshakeMessage } from "./codec";
-import { generateX25519KeyPair } from "./crypto";
+import { DH25519 } from "./dh25519";
 import { MessageNametagBufferSize } from "./messagenametag";
 import { ResponderParameters, WakuPairing } from "./pairing";
 
@@ -66,8 +66,10 @@ describe("js-noise: pairing object", () => {
   // =================
 
   it("should pair", async function () {
-    const bobStaticKey = generateX25519KeyPair();
-    const aliceStaticKey = generateX25519KeyPair();
+    const dhKey = new DH25519();
+
+    const bobStaticKey = dhKey.generateKeyPair();
+    const aliceStaticKey = dhKey.generateKeyPair();
 
     const recvParameters = new ResponderParameters();
     const bobPairingObj = new WakuPairing(sender, responder, bobStaticKey, recvParameters);
@@ -112,8 +114,9 @@ describe("js-noise: pairing object", () => {
   });
 
   it("should timeout", async function () {
-    const bobPairingObj = new WakuPairing(sender, responder, generateX25519KeyPair(), new ResponderParameters());
-    const alicePairingObj = new WakuPairing(sender, responder, generateX25519KeyPair(), bobPairingObj.getPairingInfo());
+    const dhKey = new DH25519();
+    const bobPairingObj = new WakuPairing(sender, responder, dhKey.generateKeyPair(), new ResponderParameters());
+    const alicePairingObj = new WakuPairing(sender, responder, dhKey.generateKeyPair(), bobPairingObj.getPairingInfo());
 
     const bobExecP1 = bobPairingObj.execute(1000);
     const aliceExecP1 = alicePairingObj.execute(1000);
@@ -130,8 +133,9 @@ describe("js-noise: pairing object", () => {
   });
 
   it("pairs and `meta` field is encoded", async function () {
-    const bobStaticKey = generateX25519KeyPair();
-    const aliceStaticKey = generateX25519KeyPair();
+    const dhKey = new DH25519();
+    const bobStaticKey = dhKey.generateKeyPair();
+    const aliceStaticKey = dhKey.generateKeyPair();
 
     // Encode the length of the payload
     // Not a relevant real life example

--- a/src/pairing.ts
+++ b/src/pairing.ts
@@ -124,7 +124,7 @@ export class WakuPairing {
     const preMessagePKs = [NoisePublicKey.fromPublicKey(this.qr.ephemeralKey)];
 
     this.handshake = new Handshake({
-      hsPattern: NoiseHandshakePatterns.WakuPairing,
+      hsPattern: NoiseHandshakePatterns.Noise_WakuPairing_25519_ChaChaPoly_SHA256,
       ephemeralKey: myEphemeralKey,
       staticKey: myStaticKey,
       prologue: this.qr.toByteArray(),

--- a/src/pairing.ts
+++ b/src/pairing.ts
@@ -14,7 +14,8 @@ import {
   NoiseSecureTransferDecoder,
   NoiseSecureTransferEncoder,
 } from "./codec.js";
-import { commitPublicKey, generateX25519KeyPair } from "./crypto.js";
+import { commitPublicKey } from "./crypto.js";
+import { DH25519 } from "./dh25519.js";
 import { Handshake, HandshakeResult, HandshakeStepResult, MessageNametagError } from "./handshake.js";
 import { MessageNametagLength } from "./messagenametag.js";
 import { NoiseHandshakePatterns } from "./patterns.js";
@@ -94,7 +95,7 @@ export class WakuPairing {
     private responder: IReceiver,
     private myStaticKey: KeyPair,
     pairingParameters: InitiatorParameters | ResponderParameters,
-    private myEphemeralKey: KeyPair = generateX25519KeyPair(),
+    private myEphemeralKey: KeyPair = new DH25519().generateKeyPair(),
     private readonly encoderParameters: EncoderParameters = {}
   ) {
     this.randomFixLenVal = randomBytes(32, rng);

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -2,6 +2,9 @@ import { TAG_LENGTH as ChaChaPolyTagLen } from "@stablelib/chacha20poly1305";
 import { Hash } from "@stablelib/hash";
 import { SHA256 } from "@stablelib/sha256";
 
+import { DHKey } from "./crypto";
+import { DH25519 } from "./dh25519";
+
 /**
  * The Noise tokens appearing in Noise (pre)message patterns
  * as in http://www.noiseprotocol.org/noise.html#handshake-pattern-basics
@@ -72,13 +75,18 @@ export class MessagePattern {
  * handshake pre message patterns and the handshake message patterns
  */
 export class HandshakePattern {
+  public readonly dhKey: DHKey;
+
   constructor(
     public readonly name: string,
+    dhKeyType: new () => DHKey,
     public readonly hash: new () => Hash,
     public readonly tagLen: number,
     public readonly preMessagePatterns: Array<PreMessagePattern>,
     public readonly messagePatterns: Array<MessagePattern>
-  ) {}
+  ) {
+    this.dhKey = new dhKeyType();
+  }
 
   /**
    * Check HandshakePattern equality
@@ -106,6 +114,7 @@ export class HandshakePattern {
 export const NoiseHandshakePatterns: Record<string, HandshakePattern> = {
   Noise_K1K1_25519_ChaChaPoly_SHA256: new HandshakePattern(
     "Noise_K1K1_25519_ChaChaPoly_SHA256",
+    DH25519,
     SHA256,
     ChaChaPolyTagLen,
     [
@@ -120,6 +129,7 @@ export const NoiseHandshakePatterns: Record<string, HandshakePattern> = {
   ),
   Noise_XK1_25519_ChaChaPoly_SHA256: new HandshakePattern(
     "Noise_XK1_25519_ChaChaPoly_SHA256",
+    DH25519,
     SHA256,
     ChaChaPolyTagLen,
     [new PreMessagePattern(MessageDirection.l, [NoiseTokens.s])],
@@ -131,6 +141,7 @@ export const NoiseHandshakePatterns: Record<string, HandshakePattern> = {
   ),
   Noise_XX_25519_ChaChaPoly_SHA256: new HandshakePattern(
     "Noise_XX_25519_ChaChaPoly_SHA256",
+    DH25519,
     SHA256,
     ChaChaPolyTagLen,
     [],
@@ -142,6 +153,7 @@ export const NoiseHandshakePatterns: Record<string, HandshakePattern> = {
   ),
   Noise_XXpsk0_25519_ChaChaPoly_SHA256: new HandshakePattern(
     "Noise_XXpsk0_25519_ChaChaPoly_SHA256",
+    DH25519,
     SHA256,
     ChaChaPolyTagLen,
     [],
@@ -153,6 +165,7 @@ export const NoiseHandshakePatterns: Record<string, HandshakePattern> = {
   ),
   Noise_WakuPairing_25519_ChaChaPoly_SHA256: new HandshakePattern(
     "Noise_WakuPairing_25519_ChaChaPoly_SHA256",
+    DH25519,
     SHA256,
     ChaChaPolyTagLen,
     [new PreMessagePattern(MessageDirection.l, [NoiseTokens.e])],

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -1,3 +1,6 @@
+import { Hash } from "@stablelib/hash";
+import { SHA256 } from "@stablelib/sha256";
+
 /**
  * The Noise tokens appearing in Noise (pre)message patterns
  * as in http://www.noiseprotocol.org/noise.html#handshake-pattern-basics
@@ -70,6 +73,7 @@ export class MessagePattern {
 export class HandshakePattern {
   constructor(
     public readonly name: string,
+    public readonly hash: new () => Hash,
     public readonly preMessagePatterns: Array<PreMessagePattern>,
     public readonly messagePatterns: Array<MessagePattern>
   ) {}
@@ -100,6 +104,7 @@ export class HandshakePattern {
 export const NoiseHandshakePatterns = {
   K1K1: new HandshakePattern(
     "Noise_K1K1_25519_ChaChaPoly_SHA256",
+    SHA256,
     [
       new PreMessagePattern(MessageDirection.r, [NoiseTokens.s]),
       new PreMessagePattern(MessageDirection.l, [NoiseTokens.s]),
@@ -112,6 +117,7 @@ export const NoiseHandshakePatterns = {
   ),
   XK1: new HandshakePattern(
     "Noise_XK1_25519_ChaChaPoly_SHA256",
+    SHA256,
     [new PreMessagePattern(MessageDirection.l, [NoiseTokens.s])],
     [
       new MessagePattern(MessageDirection.r, [NoiseTokens.e]),
@@ -121,6 +127,7 @@ export const NoiseHandshakePatterns = {
   ),
   XX: new HandshakePattern(
     "Noise_XX_25519_ChaChaPoly_SHA256",
+    SHA256,
     [],
     [
       new MessagePattern(MessageDirection.r, [NoiseTokens.e]),
@@ -130,6 +137,7 @@ export const NoiseHandshakePatterns = {
   ),
   XXpsk0: new HandshakePattern(
     "Noise_XXpsk0_25519_ChaChaPoly_SHA256",
+    SHA256,
     [],
     [
       new MessagePattern(MessageDirection.r, [NoiseTokens.psk, NoiseTokens.e]),
@@ -139,6 +147,7 @@ export const NoiseHandshakePatterns = {
   ),
   WakuPairing: new HandshakePattern(
     "Noise_WakuPairing_25519_ChaChaPoly_SHA256",
+    SHA256,
     [new PreMessagePattern(MessageDirection.l, [NoiseTokens.e])],
     [
       new MessagePattern(MessageDirection.r, [NoiseTokens.e, NoiseTokens.ee]),

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -1,3 +1,4 @@
+import { TAG_LENGTH as ChaChaPolyTagLen } from "@stablelib/chacha20poly1305";
 import { Hash } from "@stablelib/hash";
 import { SHA256 } from "@stablelib/sha256";
 
@@ -74,6 +75,7 @@ export class HandshakePattern {
   constructor(
     public readonly name: string,
     public readonly hash: new () => Hash,
+    public readonly tagLen: number,
     public readonly preMessagePatterns: Array<PreMessagePattern>,
     public readonly messagePatterns: Array<MessagePattern>
   ) {}
@@ -101,10 +103,11 @@ export class HandshakePattern {
 /**
  * Supported Noise handshake patterns as defined in https://rfc.vac.dev/spec/35/#specification
  */
-export const NoiseHandshakePatterns = {
-  K1K1: new HandshakePattern(
+export const NoiseHandshakePatterns: Record<string, HandshakePattern> = {
+  Noise_K1K1_25519_ChaChaPoly_SHA256: new HandshakePattern(
     "Noise_K1K1_25519_ChaChaPoly_SHA256",
     SHA256,
+    ChaChaPolyTagLen,
     [
       new PreMessagePattern(MessageDirection.r, [NoiseTokens.s]),
       new PreMessagePattern(MessageDirection.l, [NoiseTokens.s]),
@@ -115,9 +118,10 @@ export const NoiseHandshakePatterns = {
       new MessagePattern(MessageDirection.r, [NoiseTokens.se]),
     ]
   ),
-  XK1: new HandshakePattern(
+  Noise_XK1_25519_ChaChaPoly_SHA256: new HandshakePattern(
     "Noise_XK1_25519_ChaChaPoly_SHA256",
     SHA256,
+    ChaChaPolyTagLen,
     [new PreMessagePattern(MessageDirection.l, [NoiseTokens.s])],
     [
       new MessagePattern(MessageDirection.r, [NoiseTokens.e]),
@@ -125,9 +129,10 @@ export const NoiseHandshakePatterns = {
       new MessagePattern(MessageDirection.r, [NoiseTokens.s, NoiseTokens.se]),
     ]
   ),
-  XX: new HandshakePattern(
+  Noise_XX_25519_ChaChaPoly_SHA256: new HandshakePattern(
     "Noise_XX_25519_ChaChaPoly_SHA256",
     SHA256,
+    ChaChaPolyTagLen,
     [],
     [
       new MessagePattern(MessageDirection.r, [NoiseTokens.e]),
@@ -135,9 +140,10 @@ export const NoiseHandshakePatterns = {
       new MessagePattern(MessageDirection.r, [NoiseTokens.s, NoiseTokens.se]),
     ]
   ),
-  XXpsk0: new HandshakePattern(
+  Noise_XXpsk0_25519_ChaChaPoly_SHA256: new HandshakePattern(
     "Noise_XXpsk0_25519_ChaChaPoly_SHA256",
     SHA256,
+    ChaChaPolyTagLen,
     [],
     [
       new MessagePattern(MessageDirection.r, [NoiseTokens.psk, NoiseTokens.e]),
@@ -145,9 +151,10 @@ export const NoiseHandshakePatterns = {
       new MessagePattern(MessageDirection.r, [NoiseTokens.s, NoiseTokens.se]),
     ]
   ),
-  WakuPairing: new HandshakePattern(
+  Noise_WakuPairing_25519_ChaChaPoly_SHA256: new HandshakePattern(
     "Noise_WakuPairing_25519_ChaChaPoly_SHA256",
     SHA256,
+    ChaChaPolyTagLen,
     [new PreMessagePattern(MessageDirection.l, [NoiseTokens.e])],
     [
       new MessagePattern(MessageDirection.r, [NoiseTokens.e, NoiseTokens.ee]),

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -2,7 +2,6 @@ import { concat as uint8ArrayConcat } from "uint8arrays/concat";
 import { equals as uint8ArrayEquals } from "uint8arrays/equals";
 
 import { MessageNametag } from "./@types/handshake.js";
-import { Curve25519KeySize } from "./crypto.js";
 import { MessageNametagLength } from "./messagenametag.js";
 import { NoiseHandshakePatterns, PayloadV2ProtocolIDs } from "./patterns.js";
 import { NoisePublicKey } from "./publickey.js";
@@ -140,6 +139,7 @@ export class PayloadV2 {
 
     const pattern = NoiseHandshakePatterns[protocolName];
     const tagLen = pattern ? pattern.tagLen : 0;
+    const keySize = pattern ? pattern.dhKey.DHLen() : 0;
 
     i++;
 
@@ -163,13 +163,13 @@ export class PayloadV2 {
       const flag = payload[i];
       // If the key is unencrypted, we only read the X coordinate of the EC public key and we deserialize into a Noise Public Key
       if (flag === 0) {
-        const pkLen = 1 + Curve25519KeySize;
+        const pkLen = 1 + keySize;
         handshakeMessage.push(NoisePublicKey.deserialize(payload.subarray(i, i + pkLen)));
         i += pkLen;
         written += pkLen;
         // If the key is encrypted, we only read the encrypted X coordinate and the authorization tag, and we deserialize into a Noise Public Key
       } else if (flag === 1) {
-        const pkLen = 1 + Curve25519KeySize + tagLen;
+        const pkLen = 1 + keySize + tagLen;
         handshakeMessage.push(NoisePublicKey.deserialize(payload.subarray(i, i + pkLen)));
         i += pkLen;
         written += pkLen;

--- a/src/waku-noise-pairing.spec.ts
+++ b/src/waku-noise-pairing.spec.ts
@@ -1,5 +1,6 @@
 import { HMACDRBG } from "@stablelib/hmac-drbg";
 import { randomBytes } from "@stablelib/random";
+import { SHA256 } from "@stablelib/sha256";
 import { expect } from "chai";
 import { equals as uint8ArrayEquals } from "uint8arrays/equals";
 
@@ -29,6 +30,7 @@ describe("Waku Noise Sessions", () => {
     // ==========
 
     const dhKey = new DH25519();
+    const hash = SHA256;
 
     const hsPattern = NoiseHandshakePatterns.Noise_WakuPairing_25519_ChaChaPoly_SHA256;
 
@@ -36,13 +38,13 @@ describe("Waku Noise Sessions", () => {
     const aliceStaticKey = dhKey.generateKeyPair();
     const aliceEphemeralKey = dhKey.generateKeyPair();
     const s = randomBytes(32, rng);
-    const aliceCommittedStaticKey = commitPublicKey(aliceStaticKey.publicKey, s);
+    const aliceCommittedStaticKey = commitPublicKey(hash, aliceStaticKey.publicKey, s);
 
     // Bob static/ephemeral key initialization and commitment
     const bobStaticKey = dhKey.generateKeyPair();
     const bobEphemeralKey = dhKey.generateKeyPair();
     const r = randomBytes(32, rng);
-    const bobCommittedStaticKey = commitPublicKey(bobStaticKey.publicKey, r);
+    const bobCommittedStaticKey = commitPublicKey(hash, bobStaticKey.publicKey, r);
 
     // Content topic information
     const applicationName = "waku-noise-sessions";
@@ -175,7 +177,7 @@ describe("Waku Noise Sessions", () => {
     expect(uint8ArrayEquals(aliceStep.transportMessage, sentTransportMessage));
 
     // Alice further checks if Bob's commitment opens to Bob's static key she just received
-    const expectedBobCommittedStaticKey = commitPublicKey(aliceHS.hs.rs!, aliceStep.transportMessage);
+    const expectedBobCommittedStaticKey = commitPublicKey(hash, aliceHS.hs.rs!, aliceStep.transportMessage);
 
     expect(uint8ArrayEquals(expectedBobCommittedStaticKey, bobCommittedStaticKey)).to.be.true;
 
@@ -212,7 +214,7 @@ describe("Waku Noise Sessions", () => {
     expect(uint8ArrayEquals(bobStep.transportMessage, sentTransportMessage));
 
     // Bob further checks if Alice's commitment opens to Alice's static key he just received
-    const expectedAliceCommittedStaticKey = commitPublicKey(bobHS.hs.rs!, bobStep.transportMessage);
+    const expectedAliceCommittedStaticKey = commitPublicKey(hash, bobHS.hs.rs!, bobStep.transportMessage);
 
     expect(uint8ArrayEquals(expectedAliceCommittedStaticKey, aliceCommittedStaticKey)).to.be.true;
 

--- a/src/waku-noise-pairing.spec.ts
+++ b/src/waku-noise-pairing.spec.ts
@@ -27,7 +27,7 @@ describe("Waku Noise Sessions", () => {
     // Pairing Phase
     // ==========
 
-    const hsPattern = NoiseHandshakePatterns.WakuPairing;
+    const hsPattern = NoiseHandshakePatterns.Noise_WakuPairing_25519_ChaChaPoly_SHA256;
 
     // Alice static/ephemeral key initialization and commitment
     const aliceStaticKey = generateX25519KeyPair();

--- a/src/waku-noise-pairing.spec.ts
+++ b/src/waku-noise-pairing.spec.ts
@@ -9,7 +9,8 @@ import {
   NoiseSecureTransferDecoder,
   NoiseSecureTransferEncoder,
 } from "./codec";
-import { commitPublicKey, generateX25519KeyPair } from "./crypto";
+import { commitPublicKey } from "./crypto";
+import { DH25519 } from "./dh25519";
 import { Handshake } from "./handshake";
 import { MessageNametagBufferSize, MessageNametagLength } from "./messagenametag";
 import { NoiseHandshakePatterns } from "./patterns";
@@ -27,17 +28,19 @@ describe("Waku Noise Sessions", () => {
     // Pairing Phase
     // ==========
 
+    const dhKey = new DH25519();
+
     const hsPattern = NoiseHandshakePatterns.Noise_WakuPairing_25519_ChaChaPoly_SHA256;
 
     // Alice static/ephemeral key initialization and commitment
-    const aliceStaticKey = generateX25519KeyPair();
-    const aliceEphemeralKey = generateX25519KeyPair();
+    const aliceStaticKey = dhKey.generateKeyPair();
+    const aliceEphemeralKey = dhKey.generateKeyPair();
     const s = randomBytes(32, rng);
     const aliceCommittedStaticKey = commitPublicKey(aliceStaticKey.publicKey, s);
 
     // Bob static/ephemeral key initialization and commitment
-    const bobStaticKey = generateX25519KeyPair();
-    const bobEphemeralKey = generateX25519KeyPair();
+    const bobStaticKey = dhKey.generateKeyPair();
+    const bobEphemeralKey = dhKey.generateKeyPair();
     const r = randomBytes(32, rng);
     const bobCommittedStaticKey = commitPublicKey(bobStaticKey.publicKey, r);
 


### PR DESCRIPTION
In https://rfc.vac.dev/spec/70/ a new pattern is defined that uses a different DH, Cipher and Hash function.
js-noise currently only accepts 25519, ChaChaPoly and Sha256. With this PR it should be possible to use also other types as long as they follow stablelib [`Hash`](https://www.stablelib.com/modules/_stablelib_hash.html) interface, `DHKey` interface and *TODO - Define interface for Cipher*

- [x] Allow Hash customization
- [x] Allow DH customization
- [ ] Allow Cipher customization
- [ ] Use AES256GCM Cipher
- [ ] Use [x448](https://github.com/paulmillr/noble-curves#ed448-x448-decaf448) key ?
- [ ] Define `Noise_IX_448_AES256GCM_SHA256` pattern
