### PR TITLE
chore: Export `NoiseSecureMessage` class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {
   NoiseHandshakeEncoder,
   NoiseSecureTransferDecoder,
   NoiseSecureTransferEncoder,
+  NoiseSecureMessage
 } from "./codec.js";
 import { DH25519 } from "./dh25519.js";
 import {
@@ -24,6 +25,7 @@ import {
   PayloadV2ProtocolIDs,
   PreMessagePattern,
 } from "./patterns.js";
+import { PayloadV2 } from "./payload.js";
 import { NoisePublicKey } from "./publickey.js";
 import { QR } from "./qr.js";
 
@@ -47,6 +49,13 @@ export {
 };
 export { NoisePublicKey };
 export { MessageNametagBuffer };
-export { NoiseHandshakeDecoder, NoiseHandshakeEncoder, NoiseSecureTransferDecoder, NoiseSecureTransferEncoder };
+export {
+  NoiseHandshakeDecoder,
+  NoiseHandshakeEncoder,
+  NoiseSecureTransferDecoder,
+  NoiseSecureTransferEncoder,
+  NoiseSecureMessage
+};
 export { QR };
 export { InitiatorParameters, ResponderParameters, WakuPairing };
+export { PayloadV2 };


### PR DESCRIPTION
The ability to craft Noise Secure Messages externally from the library would provide valuable extensibility.
One example of this is when you want to create an override of the [`decoder`](https://github.com/waku-org/js-noise/blob/master/src/codec.ts#L177) / [`encoder`](https://github.com/waku-org/js-noise/blob/master/src/codec.ts#L121) that is generated after a handshake is successful.