### PR TITLE
feat!: determine pubsubTopic based on contentTopic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@stablelib/x25519": "^1.0.1",
         "@waku/core": "0.0.28",
         "@waku/proto": "0.0.6",
+        "@waku/utils": "^0.0.16",
         "bn.js": "^5.2.1",
         "eventemitter3": "^5.0.0",
         "p-event": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@stablelib/x25519": "^1.0.1",
     "@waku/core": "0.0.28",
     "@waku/proto": "0.0.6",
+    "@waku/utils": "^0.0.16",
     "bn.js": "^5.2.1",
     "eventemitter3": "^5.0.0",
     "p-event": "^5.0.1",

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -9,6 +9,7 @@ import {
   type IProtoMessage,
 } from "@waku/interfaces";
 import { WakuMessage } from "@waku/proto";
+import { contentTopicToPubsubTopic } from "@waku/utils";
 import debug from "debug";
 
 import { HandshakeResult, HandshakeStepResult } from "./handshake.js";
@@ -25,8 +26,6 @@ const version = 2;
  * Used internally in the pairing object to represent a handshake message
  */
 export class NoiseHandshakeMessage extends DecodedMessage implements IDecodedMessage {
-  pubSubTopic = DefaultPubsubTopic;
-
   get payloadV2(): PayloadV2 {
     if (!this.payload) throw new Error("no payload available");
     return PayloadV2.deserialize(this.payload);
@@ -43,13 +42,15 @@ export class NoiseHandshakeEncoder implements IEncoder {
    * @param hsStepResult the result of a step executed while performing the handshake process
    * @param ephemeral makes messages ephemeral in the Waku network
    */
-  pubsubTopic = DefaultPubsubTopic;
+  pubsubTopic: string;
 
   constructor(
     public contentTopic: string,
     private hsStepResult: HandshakeStepResult,
     public ephemeral: boolean = true
-  ) {}
+  ) {
+    this.pubsubTopic = contentTopicToPubsubTopic(contentTopic);
+  }
 
   async toWire(message: IMessage): Promise<Uint8Array | undefined> {
     const protoMessage = await this.toProtoObj(message);
@@ -79,9 +80,11 @@ export class NoiseHandshakeDecoder implements IDecoder<NoiseHandshakeMessage> {
   /**
    * @param contentTopic content topic on which the encoded WakuMessages were sent
    */
-  pubsubTopic = DefaultPubsubTopic;
+  pubsubTopic: string;
 
-  constructor(public contentTopic: string) {}
+  constructor(public contentTopic: string) {
+    this.pubsubTopic = contentTopicToPubsubTopic(contentTopic);
+  }
 
   fromWireToProtoObj(bytes: Uint8Array): Promise<IProtoMessage | undefined> {
     const protoMessage = WakuMessage.decode(bytes);
@@ -141,14 +144,16 @@ export class NoiseSecureTransferEncoder implements IEncoder {
    * @param ephemeral whether messages should be tagged as ephemeral defaults to true.
    * @param metaSetter callback function that set the `meta` field.
    */
-  pubsubTopic = DefaultPubsubTopic;
+  pubsubTopic: string;
 
   constructor(
     public contentTopic: string,
     private hsResult: HandshakeResult,
     public ephemeral: boolean = true,
     public metaSetter?: IMetaSetter
-  ) {}
+  ) {
+    this.pubsubTopic = contentTopicToPubsubTopic(contentTopic);
+  }
 
   async toWire(message: IMessage): Promise<Uint8Array | undefined> {
     const protoMessage = await this.toProtoObj(message);
@@ -197,9 +202,11 @@ export class NoiseSecureTransferDecoder implements IDecoder<NoiseSecureMessage> 
    * @param contentTopic content topic on which the encoded WakuMessages were sent
    * @param hsResult handshake result obtained after the handshake is successful
    */
-  pubsubTopic = DefaultPubsubTopic;
+  pubsubTopic: string;
 
-  constructor(public contentTopic: string, private hsResult: HandshakeResult) {}
+  constructor(public contentTopic: string, private hsResult: HandshakeResult) {
+    this.pubsubTopic = contentTopicToPubsubTopic(contentTopic);
+  }
 
   fromWireToProtoObj(bytes: Uint8Array): Promise<IProtoMessage | undefined> {
     const protoMessage = WakuMessage.decode(bytes);

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -1,6 +1,5 @@
 import { DecodedMessage } from "@waku/core/lib/message/version_0";
 import {
-  DefaultPubsubTopic,
   type IDecodedMessage,
   type IDecoder,
   type IEncoder,

--- a/src/pairing.spec.ts
+++ b/src/pairing.spec.ts
@@ -15,7 +15,7 @@ const PUBSUB_TOPIC = "default";
 
 const EMPTY_PROTOMESSAGE = {
   timestamp: undefined,
-  contentTopic: "",
+  contentTopic: "/noise-test/0.0.0/noise/1/0/proto",
   ephemeral: undefined,
   meta: undefined,
   rateLimitProof: undefined,

--- a/src/pairing.spec.ts
+++ b/src/pairing.spec.ts
@@ -15,7 +15,7 @@ const PUBSUB_TOPIC = "default";
 
 const EMPTY_PROTOMESSAGE = {
   timestamp: undefined,
-  contentTopic: "/noise-test/0.0.0/noise/1/0/proto",
+  contentTopic: "/js-noise/1/message/proto",
   ephemeral: undefined,
   meta: undefined,
   rateLimitProof: undefined,

--- a/src/pairing.ts
+++ b/src/pairing.ts
@@ -78,9 +78,7 @@ export class WakuPairing {
    * @returns content topic string
    */
   private static toContentTopic(qr: QR): string {
-    return (
-      "/" + qr.applicationName + "/" + qr.applicationVersion + "/" + qr.shardId + "/proto"
-    );
+    return "/" + qr.applicationName + "/" + qr.applicationVersion + "/" + qr.shardId + "/proto";
   }
 
   /**

--- a/src/pairing.ts
+++ b/src/pairing.ts
@@ -73,12 +73,13 @@ export class WakuPairing {
 
   /**
    * Convert a QR into a content topic
+   * Must follow - https://github.com/vacp2p/rfc-index/blob/main/waku/informational/23/topics.md
    * @param qr
    * @returns content topic string
    */
   private static toContentTopic(qr: QR): string {
     return (
-      "/" + qr.applicationName + "/" + qr.applicationVersion + "/wakunoise/1/sessions_shard-" + qr.shardId + "/proto"
+      "/" + qr.applicationName + "/" + qr.applicationVersion + "/" + qr.shardId + "/proto"
     );
   }
 

--- a/src/waku-noise-pairing.spec.ts
+++ b/src/waku-noise-pairing.spec.ts
@@ -68,8 +68,7 @@ describe("Waku Noise Sessions", () => {
     expect(uint8ArrayEquals(bobCommittedStaticKey, readQR.committedStaticKey)).to.be.true;
 
     // We set the contentTopic from the content topic parameters exchanged in the QR
-    const contentTopic =
-      "/" + applicationName + "/" + applicationVersion + "/" + shardId + "/proto";
+    const contentTopic = "/" + applicationName + "/" + applicationVersion + "/" + shardId + "/proto";
 
     // Pre-handshake message
     // <- eB {H(sB||r), contentTopicParams, messageNametag}

--- a/src/waku-noise-pairing.spec.ts
+++ b/src/waku-noise-pairing.spec.ts
@@ -69,7 +69,7 @@ describe("Waku Noise Sessions", () => {
 
     // We set the contentTopic from the content topic parameters exchanged in the QR
     const contentTopic =
-      "/" + applicationName + "/" + applicationVersion + "/wakunoise/1/sessions_shard-" + shardId + "/proto";
+      "/" + applicationName + "/" + applicationVersion + "/" + shardId + "/proto";
 
     // Pre-handshake message
     // <- eB {H(sB||r), contentTopicParams, messageNametag}


### PR DESCRIPTION
### Problem

In latest fleet deploy there is no support of default pubsubtopic 
Which means now it should be determined based on contentTopic